### PR TITLE
ELVIS-57 Add endpoint for getting legal orgform of main or sub entity

### DIFF
--- a/src/DsbNorge.A3Forms/Clients/Brreg/BrregClient.cs
+++ b/src/DsbNorge.A3Forms/Clients/Brreg/BrregClient.cs
@@ -232,7 +232,20 @@ public class BrregClient(
     {
         [JsonPropertyName("underenheter")] public List<BrregOrganization>? SubEntities { get; } = subEntities;
     }
+    
+    public async Task<BrregOrgForm?> GetLegalOrgForm(string organizationNumber)
+    {
+        // Sub entitites always have organisasjonsform BEDR/AAFY;
+        // the legal form (ENK/AS/NUF/...) lives on the main entity.
+        // Resolve from the parent when needed.
+        var subEntity = await GetSubEntity(organizationNumber);
+        var mainEntityNumber = string.IsNullOrWhiteSpace(subEntity?.OverordnetEnhet)
+            ? organizationNumber
+            : subEntity.OverordnetEnhet;
 
+        var entity = await GetEntity(mainEntityNumber);
+        return entity?.Organisasjonsform;
+    }
 }
 
 public enum BrregOrganizationStatus

--- a/src/DsbNorge.A3Forms/Clients/Brreg/IBrregClient.cs
+++ b/src/DsbNorge.A3Forms/Clients/Brreg/IBrregClient.cs
@@ -11,4 +11,11 @@ public interface IBrregClient
 
     public Task<BrregOrg?> GetEntity(string organizationNumber);
     public Task<BrregSubEntity?> GetSubEntity(string organizationNumber);
+    
+    /// <summary>
+    /// Returns the legal organisasjonsform (ENK, AS, NUF, ...) of the actor.
+    /// Underenheter always have form BEDR/AAFY, so when the org is an underenhet
+    /// this resolves and returns the form of its hovedenhet (overordnetEnhet).
+    /// </summary>
+    public Task<BrregOrgForm?> GetLegalOrgForm(string organizationNumber);
 }

--- a/src/DsbNorge.A3Forms/Models/BrregOrg.cs
+++ b/src/DsbNorge.A3Forms/Models/BrregOrg.cs
@@ -9,6 +9,9 @@ public class BrregOrg
 
   [JsonPropertyName("navn")]
   public string Navn { get; set; } = string.Empty;
+  
+  [JsonPropertyName("organisasjonsform")]
+  public BrregOrgForm? Organisasjonsform { get; set; }
 
   [JsonPropertyName("forretningsadresse")]
   public ForretningsAdresse? ForretningsAdresse { get; set; }

--- a/src/DsbNorge.A3Forms/Models/BrregSubEntity.cs
+++ b/src/DsbNorge.A3Forms/Models/BrregSubEntity.cs
@@ -10,6 +10,9 @@ public class BrregSubEntity
   [JsonPropertyName("navn")]
   public string Navn { get; set; } = string.Empty;
 
+  [JsonPropertyName("overordnetEnhet")]
+  public string? OverordnetEnhet { get; set; }
+
   [JsonPropertyName("organisasjonsform")]
   public BrregOrgForm Organisasjonsform { get; set; } = new();
 

--- a/test/DsbNorge.A3Forms.Tests/BrregClientTests.cs
+++ b/test/DsbNorge.A3Forms.Tests/BrregClientTests.cs
@@ -169,6 +169,65 @@ public class BrregClientTests
 
         Assert.That(status, Is.EqualTo(BrregOrganizationStatus.SubEntity));
     }
+    
+    [Test]
+      public async Task GetLegalOrgForm_returns_form_directly_for_hovedenhet()
+      {
+          _mockHttpMessageHandler.SetResponder(req =>
+          {
+              // /underenheter/{org} -> 404 (actor is a main entity)
+              if (req.RequestUri!.AbsolutePath.Contains("/underenheter/"))
+                  return new HttpResponseMessage(HttpStatusCode.NotFound);
+
+              // /enheter/{org} -> entity with organisasjonsform
+              var json = JsonSerializer.Serialize(new
+              {
+                  organisasjonsnummer = "987654321",
+                  navn = "Ola Nordmann",
+                  organisasjonsform = new { kode = "ENK", beskrivelse = "Enkeltpersonforetak" }
+              });
+              return new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(json) };
+          });
+
+          var result = await _brregClient.GetLegalOrgForm("987654321");
+
+          Assert.That(result, Is.Not.Null);
+          Assert.That(result!.Code, Is.EqualTo("ENK"));
+      }
+
+      [Test]
+      public async Task GetLegalOrgForm_resolves_hovedenhet_when_actor_is_underenhet()
+      {
+          _mockHttpMessageHandler.SetResponder(req =>
+          {
+              if (req.RequestUri!.AbsolutePath.Contains("/underenheter/"))
+              {
+                  // sub entity: own form is BEDR, but it points at its parent
+                  var sub = JsonSerializer.Serialize(new
+                  {
+                      organisasjonsnummer = "111111111",
+                      navn = "Underenhet",
+                      organisasjonsform = new { kode = "BEDR", beskrivelse = "Bedrift" },
+                      overordnetEnhet = "987654321"
+                  });
+                  return new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(sub) };
+              }
+
+              // ain entity carries the legal form
+              var entity = JsonSerializer.Serialize(new
+              {
+                  organisasjonsnummer = "987654321",
+                  navn = "Ola Nordmann",
+                  organisasjonsform = new { kode = "ENK", beskrivelse = "Enkeltpersonforetak" }
+              });
+              return new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(entity) };
+          });
+  
+          var result = await _brregClient.GetLegalOrgForm("111111111");
+
+          Assert.That(result, Is.Not.Null);
+          Assert.That(result!.Code, Is.EqualTo("ENK"));
+      }
 
     [TearDown]
     public void TearDown()

--- a/test/DsbNorge.A3Forms.Tests/resources/MockHttpMessageHandler.cs
+++ b/test/DsbNorge.A3Forms.Tests/resources/MockHttpMessageHandler.cs
@@ -17,8 +17,11 @@ public class MockHttpMessageHandler : HttpMessageHandler, IDisposable
     {
         _requestCaptureCallback?.Invoke(request);
         
-        var responseToSend = _httpResponseMessage ?? new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("[]") }; 
-                
+        var responseToSend =
+            _responder?.Invoke(request)
+            ?? _httpResponseMessage
+            ?? new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("[]") };
+        
         return Task.FromResult(responseToSend);
     }
 
@@ -32,4 +35,9 @@ public class MockHttpMessageHandler : HttpMessageHandler, IDisposable
     {
         _requestCaptureCallback = callback;
     }
+    
+    private Func<HttpRequestMessage, HttpResponseMessage>? _responder;
+
+    public void SetResponder(Func<HttpRequestMessage, HttpResponseMessage> responder)
+        => _responder = responder;
 }


### PR DESCRIPTION
Underenheter vet ikke om de er enkeltmannsforetak (eller andre ting, ENK/AS/NUF), dette ligger lagret på hovedenheten.
Noen ENK har ikke underenhet og er lagret som bare hovedenhet. 
Begge disse tilfellene håndteres og org.nummer som slås opp kan være enten underenhet eller hovedenhet.